### PR TITLE
build: Use the AWS public docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.2
+FROM public.ecr.aws/docker/library/alpine:3.13.2
 RUN apk add --no-cache bash docker-cli jq
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
To avoid getting rate limited by Docker